### PR TITLE
refactor(deploy): use subcommands for platform selection

### DIFF
--- a/deploy/__main__.py
+++ b/deploy/__main__.py
@@ -1,0 +1,35 @@
+import argparse
+import sys
+import os
+
+# 'deploy' ディレクトリをPythonのモジュール検索パスに追加
+sys.path.append(os.path.dirname(__file__))
+
+from deploy_to_android import deploy_to_android
+from deploy_to_linux import deploy_to_linux
+from deploy_to_mac import deploy_to_mac
+
+def main():
+    """
+    デプロイコマンドのエントリーポイント
+    """
+    parser = argparse.ArgumentParser(description="Deploy dotfiles to a specified platform.")
+    subparsers = parser.add_subparsers(dest="platform", required=True, help="Platform to deploy to")
+
+    # Android sub-command
+    parser_android = subparsers.add_parser("android", help="Deploy to Android")
+    parser_android.set_defaults(func=deploy_to_android)
+
+    # Linux sub-command
+    parser_linux = subparsers.add_parser("linux", help="Deploy to Linux")
+    parser_linux.set_defaults(func=deploy_to_linux)
+
+    # Mac sub-command
+    parser_mac = subparsers.add_parser("mac", help="Deploy to Mac")
+    parser_mac.set_defaults(func=deploy_to_mac)
+
+    args = parser.parse_args()
+    args.func()
+
+if __name__ == "__main__":
+    main()

--- a/deploy/deploy_to_android.py
+++ b/deploy/deploy_to_android.py
@@ -14,7 +14,7 @@ from setup_vim import setup_vim
 from create_symlink_safely import create_symlink_safely
 from paths import DOTFILES_ROOT, HOME_DIR
 
-def main():
+def deploy_to_android():
     """Android用のデプロイを実行する"""
     print("Starting deployment for Android...")
 
@@ -70,5 +70,3 @@ def _setup_git_for_platform():
 
     print("--- Platform specific Git setup complete (Android) ---\n")
 
-if __name__ == "__main__":
-    main()

--- a/deploy/deploy_to_linux.py
+++ b/deploy/deploy_to_linux.py
@@ -15,7 +15,7 @@ from deploy_configs import deploy_configs
 from setup_vim import setup_vim
 from setup_update_command import setup_update_command
 
-def main():
+def deploy_to_linux():
     """Linux用のデプロイを実行する"""
     print("Starting deployment for Linux...")
 
@@ -31,5 +31,3 @@ def main():
 
     print("\nLinux deployment finished.")
 
-if __name__ == "__main__":
-    main()

--- a/deploy/deploy_to_mac.py
+++ b/deploy/deploy_to_mac.py
@@ -17,7 +17,7 @@ from setup_vim import setup_vim
 from setup_ideavim import setup_ideavim
 from setup_update_command import setup_update_command
 
-def main():
+def deploy_to_mac():
     """macOS用のデプロイを実行する"""
     print("Starting deployment for macOS...")
 
@@ -36,5 +36,3 @@ def main():
 
     print("\nmacOS deployment finished.")
 
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
Consolidates the individual `deploy_to_*.py` scripts into a single entry point (`python3 -m deploy`). The target platform is now specified as a subcommand (e.g., `python3 -m deploy android`).

This change simplifies the deployment process and improves the command-line user interface.

Key changes:
- Created `deploy/__main__.py` to handle command-line argument parsing and subcommand routing.
- Renamed and refactored existing `deploy_to_*.py` scripts into modules containing a `deploy_to_{platform}` function.
- Made the `deploy` directory a runnable package by adding `__init__.py`.